### PR TITLE
Use the real path

### DIFF
--- a/fsdevtools-cli/src/main/archive/fs-cli.sh
+++ b/fsdevtools-cli/src/main/archive/fs-cli.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 JAVACMD="$JAVA_HOME/bin/java";
-FS_CLI_DIR="$( cd "$(dirname "$0")/../" ; pwd -P )/"
+FS_CLI_DIR="$( cd "$(dirname $(realpath "$0"))/../" ; pwd -P )/"
 $JAVACMD -Xmx512m -Dlog4j.configuration=file:"${FS_CLI_DIR}conf/log4j.properties" -cp "${FS_CLI_DIR}/lib/*" com.espirit.moddev.cli.Cli "$@";
 RETVAL=$?;
 exit ${RETVAL};


### PR DESCRIPTION
When using a full qualified path to run the fs-cli then everything works
as expected, but if the fs-cli is used via $PATH then the path detection
return rubbish.

This can be fixed by using the real path via `realpath`.