### PR TITLE
Add new service group and service start, stop and restart commands

### DIFF
--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceGroup.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceGroup.java
@@ -1,0 +1,32 @@
+/*
+ *
+ * *********************************************************************
+ * fsdevtools
+ * %%
+ * Copyright (C) 2016 e-Spirit AG
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * *********************************************************************
+ *
+ */
+
+package com.espirit.moddev.cli.commands.service;
+
+import com.github.rvesse.airline.annotations.Group;
+
+/**
+ * Service management group.
+ */
+@Group(name = "service", description = "Controls a FirstSpirit services. Start, stop or restart services. Requires an fs-access.jar on the classpath and the admin privileges.", defaultCommand = ServiceRestartCommand.class)
+public class ServiceGroup {
+}

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceProcessCommand.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceProcessCommand.java
@@ -1,0 +1,129 @@
+package com.espirit.moddev.cli.commands.service;
+
+import com.espirit.moddev.cli.ConnectionBuilder;
+import com.espirit.moddev.cli.commands.SimpleCommand;
+import com.espirit.moddev.cli.results.SimpleResult;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.OptionType;
+import de.espirit.firstspirit.access.Connection;
+import de.espirit.firstspirit.manager.ServiceManager;
+import de.espirit.firstspirit.server.ManagerProvider;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Base class to process the FirstSpirit services. Can be used to implement restart, start and stop Commands.
+ */
+public abstract class ServiceProcessCommand extends SimpleCommand<SimpleResult<Boolean>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceProcessCommand.class);
+
+    @Option(type = OptionType.COMMAND, name = {"-n", "--serviceNames"}, description = "Comma separated list of Names of the FirstSpirit services to be restarted. Optional. If not provided, all services with auto start enabled will be restarted")
+    private String serviceNames;
+
+    @Override
+    public SimpleResult<Boolean> call() {
+        try (final Connection connection = createConnection()) {
+            connection.connect();
+
+            return new SimpleResult<>(processServices(getServiceManager(connection)));
+
+        } catch (final Exception e) {
+            return new SimpleResult<>(e);
+        }
+    }
+
+    @Override
+    public boolean needsContext() {
+        return false;
+    }
+
+    /**
+     * Get configured service names als comma separated string.
+     *
+     * @return configured service names
+     */
+    public String getServiceNames() {
+        return this.serviceNames;
+    }
+
+    protected ServiceManager getServiceManager(Connection connection) {
+        if (connection instanceof ManagerProvider) {
+            final ManagerProvider managerProvider = (ManagerProvider) connection;
+            final ServiceManager serviceManager = managerProvider.getManager(ServiceManager.class);
+            if (serviceManager == null) {
+                throw new IllegalStateException("Could not retrieve the ServiceManager from ManagerProvider");
+            }
+
+            LOGGER.debug("Successfully retrieved a ServiceManager instance: class impl = '{}'", serviceManager.getClass().getName());
+            return serviceManager;
+        }
+
+        throw new IllegalStateException("Connection is not a ManagerProvider implementation.");
+    }
+
+    protected boolean processServices(final ServiceManager serviceManager) {
+
+        final List<String> serviceNames = getOptionalServiceNames();
+
+        if (serviceNames.size() > 0) {
+
+            // process provided services by name
+            for (String serviceName : serviceNames) {
+                processService(serviceManager, serviceName);
+            }
+
+        } else {
+            LOGGER.info("No --serviceNames parameter given for processing. All services with auto start enabled will be processed!");
+            // no services where provided by param ==> process all services with auto start == enabled
+            for (String serviceName : serviceManager.getServices()) {
+                if (serviceManager.isAutostartEnabled(serviceName)) {
+                    processService(serviceManager, serviceName);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Processed the service with given name
+     *
+     * @param serviceManager ServiceManager instance
+     * @param serviceName    name of service to process
+     */
+    protected abstract void processService(ServiceManager serviceManager, String serviceName);
+
+    /**
+     * Creates a connection to a FirstSpirit Server with this instance as config.
+     *
+     * @return A connection from a ConnectionBuild.
+     * @see ConnectionBuilder
+     */
+    protected Connection createConnection() {
+        return ConnectionBuilder.with(this).build();
+    }
+
+
+    /**
+     * Get configured service names als List.
+     *
+     * @return configured service names als List or empty List if no names where configured.
+     */
+    protected List<String> getOptionalServiceNames() {
+        if (StringUtils.isBlank(this.getServiceNames())) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(StringUtils.split(this.getServiceNames(), ","))
+                .filter(StringUtils::isNoneBlank)
+                .map(StringUtils::trim)
+                .collect(Collectors.toList());
+    }
+}

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceRestartCommand.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceRestartCommand.java
@@ -1,0 +1,67 @@
+/*
+ *
+ * *********************************************************************
+ * fsdevtools
+ * %%
+ * Copyright (C) 2016 e-Spirit AG
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * *********************************************************************
+ *
+ */
+
+package com.espirit.moddev.cli.commands.service;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.help.Examples;
+import de.espirit.firstspirit.manager.ServiceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Command class that can restart a FirstSpirit services.
+ *
+ * @author Andreas Straub
+ */
+@Command(name = "restart", groupNames = "service", description = "Restarts a FirstSpirit service. Starts, even if it's not running. Requires an fs-access.jar on the classpath." +
+        "PLEASE NOTE: You need an 'AdminConnection' (user with 'Admin' privileges) to be able to execute this command properly")
+@Examples(examples =
+        {
+                "service restart",
+                "service restart  -n UXBService",
+                "service restart  -n UXBService,AnotherService"
+        },
+        descriptions = {
+                "Simply restarts the all services those have auto start enabled",
+                "Simply restarts the service: 'UXBService'",
+                "Simply restarts the services: 'UXBService' and 'AnotherService'"
+        })
+
+public class ServiceRestartCommand extends ServiceProcessCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceRestartCommand.class);
+
+    @Override
+    protected void processService(final ServiceManager serviceManager, final String serviceName) {
+        if (serviceManager.isServiceRunning(serviceName)) {
+            LOGGER.info("Service: '{}' is running and will be stopped for restart!", serviceName);
+            serviceManager.stopService(serviceName);
+            LOGGER.info("Service: '{}' is stopped.", serviceName);
+        } else {
+            LOGGER.info("Service: '{}' is not running!", serviceName);
+        }
+        LOGGER.info("Try to start service: '{}'...", serviceName);
+        serviceManager.startService(serviceName);
+        LOGGER.info("Service: '{}' is started!", serviceName);
+    }
+}

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceStartCommand.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceStartCommand.java
@@ -1,0 +1,64 @@
+/*
+ *
+ * *********************************************************************
+ * fsdevtools
+ * %%
+ * Copyright (C) 2016 e-Spirit AG
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * *********************************************************************
+ *
+ */
+
+package com.espirit.moddev.cli.commands.service;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.help.Examples;
+import de.espirit.firstspirit.manager.ServiceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Command class that can start a FirstSpirit services.
+ *
+ * @author Andreas Straub
+ */
+@Command(name = "start", groupNames = "service", description = "Starts a FirstSpirit service if it is not running. Requires an fs-access.jar on the classpath." +
+        "PLEASE NOTE: You need an 'AdminConnection' (user with 'Admin' privileges) to be able to execute this command properly")
+@Examples(examples =
+        {
+                "service start",
+                "service start  -n UXBService",
+                "service start  -n UXBService,AnotherService"
+        },
+        descriptions = {
+                "Simply start the all services those have auto start enabled and currently not running",
+                "Simply start the service: 'UXBService' if it's currently not running",
+                "Simply start the services: 'UXBService' and 'AnotherService' if they currently not running"
+        })
+
+public class ServiceStartCommand extends ServiceProcessCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceStartCommand.class);
+
+    @Override
+    protected void processService(final ServiceManager serviceManager, final String serviceName) {
+        if (serviceManager.isServiceRunning(serviceName)) {
+            LOGGER.info("Service: '{}' is running and don't need to be started!", serviceName);
+        } else {
+            LOGGER.info("Try to start service: '{}'...", serviceName);
+            serviceManager.startService(serviceName);
+            LOGGER.info("Service: '{}' is started!", serviceName);
+        }
+    }
+}

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceStopCommand.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/commands/service/ServiceStopCommand.java
@@ -1,0 +1,64 @@
+/*
+ *
+ * *********************************************************************
+ * fsdevtools
+ * %%
+ * Copyright (C) 2016 e-Spirit AG
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * *********************************************************************
+ *
+ */
+
+package com.espirit.moddev.cli.commands.service;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.help.Examples;
+import de.espirit.firstspirit.manager.ServiceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Command class that can start a FirstSpirit services.
+ *
+ * @author Andreas Straub
+ */
+@Command(name = "stop", groupNames = "service", description = "Stops a FirstSpirit service if it is running. Requires an fs-access.jar on the classpath." +
+        "PLEASE NOTE: You need an 'AdminConnection' (user with 'Admin' privileges) to be able to execute this command properly")
+@Examples(examples =
+        {
+                "service stop",
+                "service stop  -n UXBService",
+                "service stop  -n UXBService,AnotherService"
+        },
+        descriptions = {
+                "Simply stop the all services those have auto start enabled and currently running",
+                "Simply stop the service: 'UXBService' if it's currently running",
+                "Simply stop the services: 'UXBService' and 'AnotherService' if they currently running"
+        })
+
+public class ServiceStopCommand extends ServiceProcessCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceStopCommand.class);
+
+    @Override
+    protected void processService(final ServiceManager serviceManager, final String serviceName) {
+        if (serviceManager.isServiceRunning(serviceName)) {
+            LOGGER.info("Service: '{}' is running and will be stopped!", serviceName);
+            serviceManager.stopService(serviceName);
+            LOGGER.info("Service: '{}' is stopped.", serviceName);
+        } else {
+            LOGGER.info("Service: '{}' is not running!", serviceName);
+        }
+    }
+}

--- a/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/commands/service/ConnectionDummy.java
+++ b/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/commands/service/ConnectionDummy.java
@@ -1,0 +1,7 @@
+package com.espirit.moddev.cli.commands.service;
+
+import de.espirit.firstspirit.access.Connection;
+import de.espirit.firstspirit.server.ManagerProvider;
+
+interface ConnectionDummy extends Connection, ManagerProvider {
+}

--- a/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/commands/service/ServiceProcessCommandTest.java
+++ b/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/commands/service/ServiceProcessCommandTest.java
@@ -1,0 +1,267 @@
+package com.espirit.moddev.cli.commands.service;
+
+import com.espirit.moddev.cli.results.SimpleResult;
+import de.espirit.firstspirit.access.Connection;
+import de.espirit.firstspirit.manager.ServiceManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for ServiceProcessCommand.
+ */
+public class ServiceProcessCommandTest {
+
+    private ServiceProcessCommand testling;
+
+    @Before
+    public void setUp() {
+        testling = new ServiceProcessCommand() {
+            @Override
+            protected void processService(ServiceManager serviceManager, String serviceName) {
+            }
+        };
+    }
+
+    /**
+     * Test that the default constructor has no dependencies or exceptions.
+     */
+    @Test
+    public void testDefaultConstructor() {
+        assertThat("Expect not null", testling, is(notNullValue()));
+    }
+
+    /**
+     * Test if call() throws exception when createConnection() fails.
+     */
+    @Test
+    public void testCallHandlesExceptionAndReturnsSimpleResultWithError() {
+        // Arrange
+        final ServiceProcessCommand spyTestling = spy(testling);
+
+        doThrow(Exception.class).when(spyTestling).createConnection();
+
+        // Act
+        final SimpleResult<Boolean> simpleResult = spyTestling.call();
+
+        // Assert
+        assertThat("Expected instance of Exception", simpleResult.getError(), instanceOf(Exception.class));
+    }
+
+
+    /**
+     * Test if call() requires an instance of ServerConnection.
+     */
+    @Test
+    public void testCallNoServerConnectionReturnsSimpleResultWithError() {
+        // Arrange
+        final Connection mockConnection = mock(Connection.class);
+
+        final ServiceProcessCommand spyTestling = spy(testling);
+
+        doReturn(mockConnection).when(spyTestling).createConnection();
+
+        // Act
+        final SimpleResult<Boolean> simpleResult = spyTestling.call();
+
+        // Assert
+        assertThat("Expected instance of IllegalStateException.", simpleResult.getError(), instanceOf(IllegalStateException.class));
+        assertThat("Expected equal.", simpleResult.getError().getMessage(), equalTo("Connection is not a ManagerProvider implementation."));
+    }
+
+    /**
+     * Test if successful restart of services with empty --serviceName parameter returns a SimpleResult containing true.
+     */
+    @Test
+    public void testCallWithEmptyServiceNamesAndNoAutoStartServicesReturnsTrue() {
+        // Arrange
+        final Connection mockConnection = mock(ConnectionDummy.class);
+        final ServiceManager mockServiceManager = mock(ServiceManager.class);
+        final ServiceProcessCommand spyTestling = spy(testling);
+        final String serviceName = "TestService";
+
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+        doReturn(mockServiceManager).when(spyTestling).getServiceManager(mockConnection);
+        when(mockServiceManager.getServices()).thenReturn(Collections.singleton(serviceName));
+        when(mockServiceManager.isAutostartEnabled(serviceName)).thenReturn(false);
+        when(mockServiceManager.isServiceRunning(serviceName)).thenReturn(true);
+
+        // Act
+        final SimpleResult<Boolean> simpleResult = spyTestling.call();
+
+        // Assert
+        assertThat("Expected equal.", simpleResult.get(), equalTo(Boolean.TRUE));
+
+        verify(mockServiceManager, times(1)).getServices();
+        verify(mockServiceManager, times(1)).isAutostartEnabled(serviceName);
+        verify(mockServiceManager, never()).isServiceRunning(serviceName);
+        verify(mockServiceManager, never()).stopService(serviceName);
+        verify(mockServiceManager, never()).startService(serviceName);
+
+    }
+
+    /**
+     * Test to retrieve the ServiceManager with wrong connection instance. Should fail with Exception.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testGetServiceManagerThrowErrorWithWrongManagerProvider() {
+        // Arrange
+        final ConnectionDummy mockConnection = mock(ConnectionDummy.class);
+        final ServiceProcessCommand spyTestling = spy(testling);
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+
+        // Act
+        spyTestling.getServiceManager(mockConnection);
+
+        // Assert
+        fail("Should trow exception");
+    }
+
+    /**
+     * Test of getting optional service names from null
+     */
+    @Test
+    public void testGetOptionalServiceNamesWithEmptyValue() {
+        // Arrange
+
+        final ServiceProcessCommand spyTestling = spy(testling);
+
+        // Act
+        List<String> serviceNames = spyTestling.getOptionalServiceNames();
+
+        // Assert
+        assertThat(serviceNames, is(emptyIterable()));
+    }
+
+    /**
+     * Test of getting optional names from "ServiceA,ServiceB"
+     */
+    @Test
+    public void testGetOptionalServiceNamesWithProvidedValue() {
+        // Arrange
+
+        final ServiceProcessCommand spyTestling = spy(testling);
+        //noinspection ResultOfMethodCallIgnored
+        doReturn("ServiceA,ServiceB").when(spyTestling).getServiceNames();
+
+        // Act
+        List<String> serviceNames = spyTestling.getOptionalServiceNames();
+
+        // Assert
+        assertThat(serviceNames, hasSize(2));
+        assertThat(serviceNames, contains("ServiceA", "ServiceB"));
+    }
+
+    /**
+     * Test of getting optional names from "ServiceA, ServiceB, Service C with Blanks in Name"
+     */
+    @Test
+    public void testGetOptionalServiceNamesWithProvidedValueWith3Items() {
+        // Arrange
+
+        final ServiceProcessCommand spyTestling = spy(testling);
+        //noinspection ResultOfMethodCallIgnored
+        doReturn("ServiceA, ServiceB, Service C with Blanks in Name").when(spyTestling).getServiceNames();
+
+        // Act
+        List<String> serviceNames = spyTestling.getOptionalServiceNames();
+
+        // Assert
+        assertThat(serviceNames, hasSize(3));
+        assertThat(serviceNames, contains("ServiceA", "ServiceB", "Service C with Blanks in Name"));
+    }
+
+    /**
+     * Test of getting optional names from "ServiceA, ServiceB, Service C with Blanks in Name"
+     */
+    @Test
+    public void testGetOptionalServiceNamesWithProvidedValueWithOneItem() {
+        // Arrange
+
+        final ServiceProcessCommand spyTestling = spy(testling);
+        //noinspection ResultOfMethodCallIgnored
+        doReturn(" ServiceA ").when(spyTestling).getServiceNames();
+
+        // Act
+        List<String> serviceNames = spyTestling.getOptionalServiceNames();
+
+        // Assert
+        assertThat(serviceNames, hasSize(1));
+        assertThat(serviceNames, hasItem("ServiceA"));
+    }
+
+
+    /**
+     * Test get optional service names from param
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testGetServiceManagerThrowErrorWithWrongConnection() {
+        // Arrange
+        final Connection mockConnection = mock(Connection.class);
+        final ServiceProcessCommand spyTestling = spy(testling);
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+
+        // Act
+        spyTestling.getServiceManager(mockConnection);
+
+        // Assert
+        fail("Should trow exception");
+    }
+
+    /**
+     * Test if successful retrieve of ServiceManager from Connection instance
+     */
+    @Test
+    public void testGetServiceManager() {
+        // Arrange
+        final ConnectionDummy mockConnection = mock(ConnectionDummy.class);
+        final ServiceProcessCommand spyTestling = spy(testling);
+        final ServiceManager mockServiceManger = mock(ServiceManager.class);
+
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+        when(mockConnection.getManager(ServiceManager.class)).thenReturn(mockServiceManger);
+
+        // Act
+        final ServiceManager serviceManager = spyTestling.getServiceManager(mockConnection);
+
+        // Assert
+        assertThat(serviceManager, is(mockServiceManger));
+        verify(mockConnection, times(1)).getManager(ServiceManager.class);
+    }
+
+    /**
+     * Test if createConnection returns an instance of Connection.class
+     */
+    @Test
+    public void testCreateConnectionReturnsInstanceOfConnection() {
+        // Arrange
+
+        // Act
+        final Connection connection = testling.createConnection();
+
+        // Assert
+        assertThat("Expect instance of Connection.class", connection, instanceOf(Connection.class));
+    }
+
+    /**
+     * Test if needsContext() is false.
+     */
+    @Test
+    public void testNeedsContextReturnsFalse() {
+        // Arrange
+
+        // Act
+
+        // Assert
+        assertThat("Expected equal", testling.needsContext(), equalTo(false));
+    }
+}
+

--- a/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/commands/service/ServiceRestartCommandTest.java
+++ b/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/commands/service/ServiceRestartCommandTest.java
@@ -1,0 +1,132 @@
+package com.espirit.moddev.cli.commands.service;
+
+import com.espirit.moddev.cli.results.SimpleResult;
+import de.espirit.firstspirit.access.Connection;
+import de.espirit.firstspirit.manager.ServiceManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for ServiceRestartCommand.
+ */
+public class ServiceRestartCommandTest {
+
+    private ServiceRestartCommand testling;
+
+    @Before
+    public void setUp() {
+        testling = new ServiceRestartCommand();
+    }
+
+    /**
+     * Test that the default constructor has no dependencies or exceptions.
+     */
+    @Test
+    public void testDefaultConstructor() {
+        assertThat("Expect not null", testling, is(notNullValue()));
+    }
+
+    /**
+     * Test if successful restart of services returns a SimpleResult containing true.
+     */
+    @Test
+    public void testCallWithEmptyServiceNamesReturnsTrue() {
+        // Arrange
+        final Connection mockConnection = mock(ConnectionDummy.class);
+        final ServiceManager mockServiceManager = mock(ServiceManager.class);
+        final ServiceRestartCommand spyTestling = spy(testling);
+        final String serviceName = "TestService";
+
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+        doReturn(mockServiceManager).when(spyTestling).getServiceManager(mockConnection);
+        when(mockServiceManager.getServices()).thenReturn(Collections.singleton(serviceName));
+        when(mockServiceManager.isAutostartEnabled(serviceName)).thenReturn(true);
+        when(mockServiceManager.isServiceRunning(serviceName)).thenReturn(true);
+
+        // Act
+        final SimpleResult<Boolean> simpleResult = spyTestling.call();
+
+        // Assert
+        assertThat("Expected equal.", simpleResult.get(), equalTo(Boolean.TRUE));
+
+        verify(mockServiceManager, times(1)).getServices();
+        verify(mockServiceManager, times(1)).isServiceRunning(serviceName);
+        verify(mockServiceManager, times(1)).isAutostartEnabled(serviceName);
+        verify(mockServiceManager, times(1)).stopService(serviceName);
+        verify(mockServiceManager, times(1)).startService(serviceName);
+
+    }
+
+    /**
+     * Test if successful restart of services with empty --serviceName parameter returns a SimpleResult containing true.
+     */
+    @Test
+    public void testCallWithEmptyServiceNamesAndNoAutoStartServicesReturnsTrue() {
+        // Arrange
+        final Connection mockConnection = mock(ConnectionDummy.class);
+        final ServiceManager mockServiceManager = mock(ServiceManager.class);
+        final ServiceRestartCommand spyTestling = spy(testling);
+        final String serviceName = "TestService";
+
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+        doReturn(mockServiceManager).when(spyTestling).getServiceManager(mockConnection);
+        when(mockServiceManager.getServices()).thenReturn(Collections.singleton(serviceName));
+        when(mockServiceManager.isAutostartEnabled(serviceName)).thenReturn(false);
+        when(mockServiceManager.isServiceRunning(serviceName)).thenReturn(true);
+
+        // Act
+        final SimpleResult<Boolean> simpleResult = spyTestling.call();
+
+        // Assert
+        assertThat("Expected equal.", simpleResult.get(), equalTo(Boolean.TRUE));
+
+        verify(mockServiceManager, times(1)).getServices();
+        verify(mockServiceManager, times(1)).isAutostartEnabled(serviceName);
+        verify(mockServiceManager, never()).isServiceRunning(serviceName);
+        verify(mockServiceManager, never()).stopService(serviceName);
+        verify(mockServiceManager, never()).startService(serviceName);
+
+    }
+
+    /**
+     * Test if successful restart of services with provided --serviceName parameter returns a SimpleResult containing true.
+     */
+    @Test
+    public void testCallWithProvidedServiceNamesServicesReturnsTrue() {
+        // Arrange
+        final Connection mockConnection = mock(ConnectionDummy.class);
+        final ServiceManager mockServiceManager = mock(ServiceManager.class);
+        final ServiceRestartCommand spyTestling = spy(testling);
+        final List<String> serviceNames = Arrays.asList("TestService", "TestService2");
+
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+
+        doReturn(mockServiceManager).when(spyTestling).getServiceManager(mockConnection);
+        doReturn(serviceNames).when(spyTestling).getOptionalServiceNames();
+
+        when(mockServiceManager.isAutostartEnabled(anyString())).thenReturn(true);
+        when(mockServiceManager.isServiceRunning(anyString())).thenReturn(true);
+
+        // Act
+        final SimpleResult<Boolean> simpleResult = spyTestling.call();
+
+        // Assert
+        assertThat("Expected equal.", simpleResult.get(), equalTo(Boolean.TRUE));
+
+        verify(mockServiceManager, never()).getServices();
+        verify(mockServiceManager, never()).isAutostartEnabled(anyString());
+        verify(mockServiceManager, times(serviceNames.size())).isServiceRunning(anyString());
+        verify(mockServiceManager, times(serviceNames.size())).stopService(anyString());
+        verify(mockServiceManager, times(serviceNames.size())).startService(anyString());
+
+    }
+}
+

--- a/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/commands/service/ServiceStartCommandTest.java
+++ b/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/commands/service/ServiceStartCommandTest.java
@@ -1,0 +1,132 @@
+package com.espirit.moddev.cli.commands.service;
+
+import com.espirit.moddev.cli.results.SimpleResult;
+import de.espirit.firstspirit.access.Connection;
+import de.espirit.firstspirit.manager.ServiceManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for ServiceStartCommand.
+ */
+public class ServiceStartCommandTest {
+
+    private ServiceStartCommand testling;
+
+    @Before
+    public void setUp() {
+        testling = new ServiceStartCommand();
+    }
+
+    /**
+     * Test that the default constructor has no dependencies or exceptions.
+     */
+    @Test
+    public void testDefaultConstructor() {
+        assertThat("Expect not null", testling, is(notNullValue()));
+    }
+
+    /**
+     * Test if successful restart of services returns a SimpleResult containing true.
+     */
+    @Test
+    public void testCallWithEmptyServiceNamesReturnsTrue() {
+        // Arrange
+        final Connection mockConnection = mock(ConnectionDummy.class);
+        final ServiceManager mockServiceManager = mock(ServiceManager.class);
+        final ServiceStartCommand spyTestling = spy(testling);
+        final String serviceName = "TestService";
+
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+        doReturn(mockServiceManager).when(spyTestling).getServiceManager(mockConnection);
+        when(mockServiceManager.getServices()).thenReturn(Collections.singleton(serviceName));
+        when(mockServiceManager.isAutostartEnabled(serviceName)).thenReturn(true);
+        when(mockServiceManager.isServiceRunning(serviceName)).thenReturn(true);
+
+        // Act
+        final SimpleResult<Boolean> simpleResult = spyTestling.call();
+
+        // Assert
+        assertThat("Expected equal.", simpleResult.get(), equalTo(Boolean.TRUE));
+
+        verify(mockServiceManager, times(1)).getServices();
+        verify(mockServiceManager, times(1)).isServiceRunning(serviceName);
+        verify(mockServiceManager, times(1)).isAutostartEnabled(serviceName);
+        verify(mockServiceManager, never()).stopService(serviceName);
+        verify(mockServiceManager, never()).startService(serviceName);
+
+    }
+
+    /**
+     * Test if successful restart of services with empty --serviceName parameter returns a SimpleResult containing true.
+     */
+    @Test
+    public void testCallWithEmptyServiceNamesAndNoAutoStartServicesReturnsTrue() {
+        // Arrange
+        final Connection mockConnection = mock(ConnectionDummy.class);
+        final ServiceManager mockServiceManager = mock(ServiceManager.class);
+        final ServiceStartCommand spyTestling = spy(testling);
+        final String serviceName = "TestService";
+
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+        doReturn(mockServiceManager).when(spyTestling).getServiceManager(mockConnection);
+        when(mockServiceManager.getServices()).thenReturn(Collections.singleton(serviceName));
+        when(mockServiceManager.isAutostartEnabled(serviceName)).thenReturn(false);
+        when(mockServiceManager.isServiceRunning(serviceName)).thenReturn(true);
+
+        // Act
+        final SimpleResult<Boolean> simpleResult = spyTestling.call();
+
+        // Assert
+        assertThat("Expected equal.", simpleResult.get(), equalTo(Boolean.TRUE));
+
+        verify(mockServiceManager, times(1)).getServices();
+        verify(mockServiceManager, times(1)).isAutostartEnabled(serviceName);
+        verify(mockServiceManager, never()).isServiceRunning(serviceName);
+        verify(mockServiceManager, never()).stopService(serviceName);
+        verify(mockServiceManager, never()).startService(serviceName);
+
+    }
+
+    /**
+     * Test if successful restart of services with provided --serviceName parameter returns a SimpleResult containing true.
+     */
+    @Test
+    public void testCallWithProvidedServiceNamesServicesReturnsTrue() {
+        // Arrange
+        final Connection mockConnection = mock(ConnectionDummy.class);
+        final ServiceManager mockServiceManager = mock(ServiceManager.class);
+        final ServiceStartCommand spyTestling = spy(testling);
+        final List<String> serviceNames = Arrays.asList("TestService", "TestService2");
+
+        when(spyTestling.createConnection()).thenReturn(mockConnection);
+
+        doReturn(mockServiceManager).when(spyTestling).getServiceManager(mockConnection);
+        doReturn(serviceNames).when(spyTestling).getOptionalServiceNames();
+
+        when(mockServiceManager.isAutostartEnabled(anyString())).thenReturn(true);
+        when(mockServiceManager.isServiceRunning(anyString())).thenReturn(false);
+
+        // Act
+        final SimpleResult<Boolean> simpleResult = spyTestling.call();
+
+        // Assert
+        assertThat("Expected equal.", simpleResult.get(), equalTo(Boolean.TRUE));
+
+        verify(mockServiceManager, never()).getServices();
+        verify(mockServiceManager, never()).isAutostartEnabled(anyString());
+        verify(mockServiceManager, times(serviceNames.size())).isServiceRunning(anyString());
+        verify(mockServiceManager, never()).stopService(anyString());
+        verify(mockServiceManager, times(serviceNames.size())).startService(anyString());
+
+    }
+}
+


### PR DESCRIPTION
Added the new command group: "service" to fs-cli to be able to "start", "stop" and "restart" the services of a first spirit server instance. In our setup we using the service restart command to restart some services after module installation. 
