### PR TITLE
Feature/enable proxy connection to fs server

### DIFF
--- a/fsdevtools-cli-api/src/main/java/com/espirit/moddev/cli/api/configuration/Config.java
+++ b/fsdevtools-cli-api/src/main/java/com/espirit/moddev/cli/api/configuration/Config.java
@@ -50,6 +50,20 @@ public interface Config {
     Integer getPort();
 
     /**
+     * Get the Proxy host.
+     *
+     * @return the Proxy host
+     */
+    String getProxyHost();
+
+    /**
+     * Get the Proxy server port.
+     *
+     * @return the Proxy server port
+     */
+    Integer getProxyPort();
+
+    /**
      * Get the connection mode used to connect to the FirstSpirit server.
      *
      * @return a {@link com.espirit.moddev.cli.api.FsConnectionMode} object that specifies the connection mode used to connect to the FirstSpirit server

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/Cli.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/Cli.java
@@ -148,6 +148,7 @@ public final class Cli {
         final Object[] argsVersion =
             {CliConstants.FS_CLI, buildProperties.getProperty("fs.cli.build.version"), gitProperties.getProperty("git.hash")};
         LOGGER.info("{} version {} / git hash {}", argsVersion);
+        LOGGER.info("Experimental version with Proxy Support - bridgingIT for Bosch");
         LOGGER.info("Build for FirstSpirit version {}", new Object[]{buildProperties.getProperty("fs.cli.fs.version")});
         String jarFilePath = System.getenv("jarfile") != null ? System.getenv("jarfile") : System.getenv("JARFILE");
         if (jarFilePath != null) {

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/Cli.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/Cli.java
@@ -148,7 +148,6 @@ public final class Cli {
         final Object[] argsVersion =
             {CliConstants.FS_CLI, buildProperties.getProperty("fs.cli.build.version"), gitProperties.getProperty("git.hash")};
         LOGGER.info("{} version {} / git hash {}", argsVersion);
-        LOGGER.info("Experimental version with Proxy Support - bridgingIT for Bosch");
         LOGGER.info("Build for FirstSpirit version {}", new Object[]{buildProperties.getProperty("fs.cli.fs.version")});
         String jarFilePath = System.getenv("jarfile") != null ? System.getenv("jarfile") : System.getenv("JARFILE");
         if (jarFilePath != null) {

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/CliConstants.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/CliConstants.java
@@ -60,6 +60,16 @@ public enum CliConstants {
     DEFAULT_IMPORT_COMMENT("Imported by fs-cli"),
 
     /**
+     * Key proxy host cli constant.
+     */
+    KEY_FS_PROXYHOST("fsproxyhost"),
+
+    /**
+     * Key proxy port cli constant.
+     */
+    KEY_FS_PROXYPORT("fsproxyport"),
+
+    /**
      * Key fs host cli constant.
      */
     KEY_FS_HOST("fshost"),

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/ConnectionBuilder.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/ConnectionBuilder.java
@@ -30,6 +30,7 @@ import com.espirit.moddev.cli.api.validation.Voilation;
 import de.espirit.firstspirit.access.Connection;
 import de.espirit.firstspirit.access.ConnectionManager;
 
+import de.espirit.firstspirit.access.Proxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +76,10 @@ public class ConnectionBuilder {
             ConnectionManager.setUseHttps(true);
         } else {
             ConnectionManager.setUseHttps(false);
+        }
+
+        if (!config.getProxyHost().isEmpty()) {
+            ConnectionManager.setProxy(new Proxy(config.getProxyHost(), config.getProxyPort()));
         }
 
         final String user = config.getUser();

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/configuration/GlobalConfig.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/configuration/GlobalConfig.java
@@ -72,6 +72,12 @@ public class GlobalConfig implements Config {
     @Option(type = OptionType.GLOBAL, name = {"-port"}, description = "FirstSpirit host's port. Default is 8000.")
     private Integer port;
 
+    @Option(type = OptionType.GLOBAL, name = {"-ph", "--proxyhost"}, description = "Proxy host.")
+    private String proxyHost;
+
+    @Option(type = OptionType.GLOBAL, name = {"-proxyport"}, description = "Proxy host's port. Default is 80.")
+    private Integer proxyPort;
+
     @Option(type = OptionType.GLOBAL, name = {"-u", "--user"}, description = "FirstSpirit user. Default is Admin.")
     private String user;
 
@@ -124,6 +130,30 @@ public class GlobalConfig implements Config {
      */
     public Environment getEnvironment() {
         return environment;
+    }
+
+    @Override
+    public String getProxyHost() {
+        if(proxyHost == null || proxyHost.isEmpty()) {
+            boolean environmentContainsHost = getEnvironment().containsKey(CliConstants.KEY_FS_PROXYHOST.value());
+            if(environmentContainsHost) {
+                return getEnvironment().get(CliConstants.KEY_FS_PROXYHOST.value()).trim();
+            }
+            return "";
+        }
+        return proxyHost;
+    }
+
+    @Override
+    public Integer getProxyPort() {
+        if(proxyPort == null) {
+            boolean environmentContainsPort = getEnvironment().containsKey(CliConstants.KEY_FS_PROXYPORT.value());
+            if(environmentContainsPort) {
+                return Integer.valueOf(getEnvironment().get(CliConstants.KEY_FS_PROXYPORT.value()).trim());
+            }
+            return 80;
+        }
+        return proxyPort;
     }
 
     @Override

--- a/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/configuration/GlobalConfig.java
+++ b/fsdevtools-cli/src/main/java/com/espirit/moddev/cli/configuration/GlobalConfig.java
@@ -75,7 +75,7 @@ public class GlobalConfig implements Config {
     @Option(type = OptionType.GLOBAL, name = {"-ph", "--proxyhost"}, description = "Proxy host.")
     private String proxyHost;
 
-    @Option(type = OptionType.GLOBAL, name = {"-proxyport"}, description = "Proxy host's port. Default is 80.")
+    @Option(type = OptionType.GLOBAL, name = {"-proxyport"}, description = "Proxy host's port. Default is 8080.")
     private Integer proxyPort;
 
     @Option(type = OptionType.GLOBAL, name = {"-u", "--user"}, description = "FirstSpirit user. Default is Admin.")
@@ -151,7 +151,7 @@ public class GlobalConfig implements Config {
             if(environmentContainsPort) {
                 return Integer.valueOf(getEnvironment().get(CliConstants.KEY_FS_PROXYPORT.value()).trim());
             }
-            return 80;
+            return 8080;
         }
         return proxyPort;
     }

--- a/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/api/parsing/exceptions/CliErrorTest.java
+++ b/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/api/parsing/exceptions/CliErrorTest.java
@@ -79,6 +79,16 @@ public class CliErrorTest {
             }
 
             @Override
+            public String getProxyHost() {
+                return "";
+            }
+
+            @Override
+            public Integer getProxyPort() {
+                return 80;
+            }
+
+            @Override
             public FsConnectionMode getConnectionMode() {
                 return null;
             }

--- a/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/legacy/SyncDirectoryFactoryTest.java
+++ b/fsdevtools-cli/src/test/java/com/espirit/moddev/cli/legacy/SyncDirectoryFactoryTest.java
@@ -65,6 +65,16 @@ public class SyncDirectoryFactoryTest {
             }
 
             @Override
+            public String getProxyHost() {
+                return "";
+            }
+
+            @Override
+            public Integer getProxyPort() {
+                return 80;
+            }
+
+            @Override
             public FsConnectionMode getConnectionMode() {
                 return null;
             }

--- a/fsdevtools-core/pom.xml
+++ b/fsdevtools-core/pom.xml
@@ -46,6 +46,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>13.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
As discussed in #12 (https://github.com/e-Spirit/FSDevTools/issues/12) we have added proxy support for the FS-Dev Tools using the already used Connection Manager.

Therefore only proxy host and port can be configured. Using a proxy with authentication is not possible since the FirstSpirit connection manager does not support this.

Please review and merge into the official release of the FS-Dev Tools since other customer may want this to.

If you have any questions just contact me.


Greetings
Sandro